### PR TITLE
Focus Atom application  when text-synced from chrome browser

### DIFF
--- a/lib/atomic-chrome.coffee
+++ b/lib/atomic-chrome.coffee
@@ -1,8 +1,5 @@
-{CompositeDisposable} = require 'atom'
-{Server}              = require 'ws'
-
-WSHandler             = require './ws-handler'
-
+{Server} = require 'ws'
+WSHandler = null # defer require till necessary
 WS_PORT = 64292
 
 module.exports = AtomicChrome =
@@ -10,6 +7,7 @@ module.exports = AtomicChrome =
     @wss = new Server({port: WS_PORT})
 
     @wss.on 'connection', (ws) ->
+      WSHandler ?= require './ws-handler'
       new WSHandler(ws)
     @wss.on 'error', (err) ->
       console.error(err) unless err.code == 'EADDRINUSE'

--- a/lib/ws-handler.coffee
+++ b/lib/ws-handler.coffee
@@ -13,6 +13,7 @@ module.exports = class WSHandler
 
   register: (data) ->
     filepath = @getFile(data)
+    atom.focus() # activivate Atom application
     atom.workspace.open(filepath).then (editor) =>
       @initEditor(editor, data)
 


### PR DESCRIPTION
This is we discussed in https://github.com/tuvistavie/atomic-chrome/issues/28

But it reveals it's achievable only by atomic-chrome-atom side.

And I could see slight activation time reduction from 40ms/avg to 30ms/avg by deferred require for ws-handler.

I can make it config option (e.g. `automaticallyActivateAtomWindow` ), but IMO this is all user's expectation so didn't do that.

How do you think?